### PR TITLE
Fix haddock

### DIFF
--- a/src/Language/Haskell/LSP/Test/Session.hs
+++ b/src/Language/Haskell/LSP/Test/Session.hs
@@ -73,7 +73,7 @@ type Session = ParserStateReader FromServerMessage SessionState SessionContext I
 data SessionConfig = SessionConfig
   { messageTimeout :: Int  -- ^ Maximum time to wait for a message in seconds, defaults to 60.
   , logStdErr      :: Bool -- ^ Redirect the server's stderr to this stdout, defaults to False.
-  , logMessages    :: Bool -- ^ Trace the messages sent and received to stdout, defaults to True.
+  , logMessages    :: Bool -- ^ Trace the messages sent and received to stdout, defaults to False.
   , logColor       :: Bool -- ^ Add ANSI color to the logged messages, defaults to True.
   }
 


### PR DESCRIPTION
It's funny how much one can learn thanks to one haddock typo :D I had some fun yesterday trying to enable logging in haskell-ide-server tests before I found that the haddocks don't correspond to the implementation. Compare with line 82 in the same file.