### PR TITLE
Update for GHC 8.6.1

### DIFF
--- a/src/Language/Haskell/LSP/Test/Parsing.hs
+++ b/src/Language/Haskell/LSP/Test/Parsing.hs
@@ -137,7 +137,9 @@ loggingNotification = named "Logging notification" $ satisfy shouldSkip
 -- (textDocument/publishDiagnostics) notification.
 publishDiagnosticsNotification :: Session PublishDiagnosticsNotification
 publishDiagnosticsNotification = named "Publish diagnostics notification" $ do
-  NotPublishDiagnostics diags <- satisfy test
-  return diags
+  mdiags <- satisfy test
+  case mdiags of
+    NotPublishDiagnostics diags -> return diags
+    _ -> error "publishDiagnosticsNotification match fail"
   where test (NotPublishDiagnostics _) = True
         test _ = False

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,7 @@
-resolver: lts-12.9
+resolver: lts-12.17
 packages:
   - .
 
 extra-deps:
-  - haskell-lsp-0.8.0.0
-  - haskell-lsp-types-0.8.0.0
+  - haskell-lsp-0.8.0.1
+  - haskell-lsp-types-0.8.0.1


### PR DESCRIPTION
And bump resolver / deps

I took the long-winded approach of actually dealing with each match, rather than adding a `fail` instance.

But perhaps for general usability it would be good to have one, for the tests anyway.