### PR TITLE
Add Type definition request

### DIFF
--- a/src/Language/Haskell/LSP/Test.hs
+++ b/src/Language/Haskell/LSP/Test.hs
@@ -65,6 +65,7 @@ module Language.Haskell.LSP.Test
   , getReferences
   -- ** Definitions
   , getDefinitions
+  , getTypeDefinitions
   -- ** Renaming
   , rename
   -- ** Hover
@@ -493,6 +494,14 @@ getDefinitions :: TextDocumentIdentifier -- ^ The document the term is in.
 getDefinitions doc pos =
   let params = TextDocumentPositionParams doc pos
   in getResponseResult <$> request TextDocumentDefinition params
+
+-- | Returns the type definition(s) for the term at the specified position.
+getTypeDefinitions :: TextDocumentIdentifier -- ^ The document the term is in.
+               -> Position -- ^ The position the term is at.
+               -> Session [Location] -- ^ The location(s) of the definitions
+getTypeDefinitions doc pos =
+  let params = TextDocumentPositionParams doc pos
+  in getResponseResult <$> request TextDocumentTypeDefinition params
 
 -- | Renames the term at the specified position.
 rename :: TextDocumentIdentifier -> Position -> String -> Session ()

--- a/src/Language/Haskell/LSP/Test/Decoding.hs
+++ b/src/Language/Haskell/LSP/Test/Decoding.hs
@@ -72,6 +72,7 @@ getRequestMap = foldl helper HM.empty
     (ReqCompletionItemResolve val) -> insert val acc
     (ReqSignatureHelp val) -> insert val acc
     (ReqDefinition val) -> insert val acc
+    (ReqTypeDefinition val) -> insert val acc
     (ReqFindReferences val) -> insert val acc
     (ReqDocumentHighlights val) -> insert val acc
     (ReqDocumentSymbols val) -> insert val acc
@@ -99,6 +100,7 @@ matchResponseMsgType req = case req of
   CompletionItemResolve         -> RspCompletionItemResolve . decoded
   TextDocumentSignatureHelp     -> RspSignatureHelp . decoded
   TextDocumentDefinition        -> RspDefinition . decoded
+  TextDocumentTypeDefinition    -> RspTypeDefinition . decoded
   TextDocumentReferences        -> RspFindReferences . decoded
   TextDocumentDocumentHighlight -> RspDocumentHighlights . decoded
   TextDocumentDocumentSymbol    -> RspDocumentSymbols . decoded

--- a/src/Language/Haskell/LSP/Test/Messages.hs
+++ b/src/Language/Haskell/LSP/Test/Messages.hs
@@ -13,6 +13,7 @@ isServerResponse (RspCompletion               _) = True
 isServerResponse (RspCompletionItemResolve    _) = True
 isServerResponse (RspSignatureHelp            _) = True
 isServerResponse (RspDefinition               _) = True
+isServerResponse (RspTypeDefinition           _) = True
 isServerResponse (RspFindReferences           _) = True
 isServerResponse (RspDocumentHighlights       _) = True
 isServerResponse (RspDocumentSymbols          _) = True

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -259,12 +259,12 @@ main = hspec $ do
       defs <- getDefinitions doc pos
       liftIO $ defs `shouldBe` [Location (doc ^. uri) (mkRange 28 0 28 7)]
 
-  describe "getTypeDefinitions" $
-    it "works" $ runSession "hie" fullCaps "test/data/renamePass" $ do
-      doc <- openDoc "Desktop/simple.hs" "haskell"
-      let pos = Position 20 23  -- Quit value
-      defs <- getTypeDefinitions doc pos
-      liftIO $ defs `shouldBe` [Location (doc ^. uri) (mkRange 10 15 10 19)]  -- First constructor
+  -- describe "getTypeDefinitions" $
+  --   it "works" $ runSession "hie" fullCaps "test/data/renamePass" $ do
+  --     doc <- openDoc "Desktop/simple.hs" "haskell"
+  --     let pos = Position 20 23  -- Quit value
+  --     defs <- getTypeDefinitions doc pos
+  --     liftIO $ defs `shouldBe` [Location (doc ^. uri) (mkRange 10 5 10 12)]  -- Type definition
 
   describe "waitForDiagnosticsSource" $
     it "works" $ runSession "hie" fullCaps "test/data" $ do

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -259,6 +259,13 @@ main = hspec $ do
       defs <- getDefinitions doc pos
       liftIO $ defs `shouldBe` [Location (doc ^. uri) (mkRange 28 0 28 7)]
 
+  describe "getTypeDefinitions" $
+    it "works" $ runSession "hie" fullCaps "test/data/renamePass" $ do
+      doc <- openDoc "Desktop/simple.hs" "haskell"
+      let pos = Position 20 23  -- Quit value
+      defs <- getTypeDefinitions doc pos
+      liftIO $ defs `shouldBe` [Location (doc ^. uri) (mkRange 10 15 10 19)]  -- First constructor
+
   describe "waitForDiagnosticsSource" $
     it "works" $ runSession "hie" fullCaps "test/data" $ do
       openDoc "Error.hs" "haskell"


### PR DESCRIPTION
Adds function `getTypeDefinitions` to the public API.
Add single test for `hie`.
~~Works with HIE version in [#1107](https://github.com/haskell/haskell-ide-engine/pull/1107)~~
Does not work yet
