### PR TITLE
Fix various issues encountered on Windows

### DIFF
--- a/lsp-test.cabal
+++ b/lsp-test.cabal
@@ -40,6 +40,7 @@ library
                      , aeson
                      , aeson-pretty
                      , ansi-terminal
+                     , async
                      , bytestring
                      , conduit
                      , conduit-parse

--- a/src/Language/Haskell/LSP/Test/Session.hs
+++ b/src/Language/Haskell/LSP/Test/Session.hs
@@ -197,6 +197,10 @@ runSessionWithHandles serverIn serverOut serverHandler config caps rootDir sessi
 
   hSetBuffering serverIn  NoBuffering
   hSetBuffering serverOut NoBuffering
+  -- This is required to make sure that we don’t get any
+  -- newline conversion or weird encoding issues.
+  hSetBinaryMode serverIn True
+  hSetBinaryMode serverOut True
 
   reqMap <- newMVar newRequestMap
   messageChan <- newChan


### PR DESCRIPTION
There are a few things going on here, some specific to Windows and some are
race conditions that are just easier to hit on Windows but can be
reproduced on Linux if you add some delays.

1. You can’t kill threads on Windows that are blocked in an hGet.
   So what you have to do is to make the hGet fail somehow, e.g., by
   terminating the process that the hGet is reading from which will
   make hGet fail.

2. You already terminate the process by sending the exit notification.
   However, there is a race condition where listenServer will throw an
   UnexpectedServerTermination exception after the server has
   terminated as a result of the exit notification. On Linux, you
   usually get lucky and end up killing the listenServer thread first
   but due to 1 you always hit this on Windows. If you add a delay
   after sending the exit notification you can also reproduce this on
   Linux.

3. You need to set the handles to binary mode. Otherwise you end up
   with newline conversions turning \r\n into \n which will cause
   parse errors.