### PR TITLE
Update to current state of progress reporting in LSP

### DIFF
--- a/lsp-test.cabal
+++ b/lsp-test.cabal
@@ -36,7 +36,7 @@ library
                      , parser-combinators:Control.Applicative.Combinators
   default-language:    Haskell2010
   build-depends:       base >= 4.10 && < 5
-                     , haskell-lsp == 0.16.*
+                     , haskell-lsp == 0.17.*
                      , aeson
                      , aeson-pretty
                      , ansi-terminal
@@ -79,7 +79,7 @@ test-suite tests
   build-depends:       base >= 4.10 && < 5
                      , hspec
                      , lens
-                     , haskell-lsp == 0.16.*
+                     , haskell-lsp == 0.17.*
                      , lsp-test
                      , data-default
                      , aeson

--- a/src/Language/Haskell/LSP/Test/Decoding.hs
+++ b/src/Language/Haskell/LSP/Test/Decoding.hs
@@ -3,6 +3,7 @@ module Language.Haskell.LSP.Test.Decoding where
 
 import           Prelude                 hiding ( id )
 import           Data.Aeson
+import           Data.Foldable
 import           Control.Exception
 import           Control.Lens
 import qualified Data.ByteString.Lazy.Char8    as B
@@ -131,9 +132,9 @@ decodeFromServerMsg reqMap bytes =
         WindowShowMessage              -> NotShowMessage $ fromJust $ decode bytes
         WindowLogMessage               -> NotLogMessage $ fromJust $ decode bytes
         CancelRequestServer            -> NotCancelRequestFromServer $ fromJust $ decode bytes
-        WindowProgressStart            -> NotProgressStart $ fromJust $ decode bytes
-        WindowProgressReport           -> NotProgressReport $ fromJust $ decode bytes
-        WindowProgressDone             -> NotProgressDone $ fromJust $ decode bytes
+        Progress                       ->
+          fromJust $ asum [NotWorkDoneProgressBegin <$> decode bytes, NotWorkDoneProgressReport <$> decode bytes, NotWorkDoneProgressEnd <$> decode bytes]
+        WindowWorkDoneProgressCreate   -> ReqWorkDoneProgressCreate $ fromJust $ decode bytes
         TelemetryEvent                 -> NotTelemetry $ fromJust $ decode bytes
         WindowShowMessageRequest       -> ReqShowMessage $ fromJust $ decode bytes
         ClientRegisterCapability       -> ReqRegisterCapability $ fromJust $ decode bytes

--- a/src/Language/Haskell/LSP/Test/Messages.hs
+++ b/src/Language/Haskell/LSP/Test/Messages.hs
@@ -60,6 +60,7 @@ handleServerMessage request response notification msg = case msg of
     (ReqShowMessage              m) -> request m
     (ReqUnregisterCapability     m) -> request m
     (ReqCustomServer             m) -> request m
+    (ReqWorkDoneProgressCreate   m) -> request m
     (RspInitialize               m) -> response m
     (RspShutdown                 m) -> response m
     (RspHover                    m) -> response m
@@ -92,9 +93,9 @@ handleServerMessage request response notification msg = case msg of
     (NotPublishDiagnostics       m) -> notification m
     (NotLogMessage               m) -> notification m
     (NotShowMessage              m) -> notification m
-    (NotProgressStart            m) -> notification m
-    (NotProgressReport           m) -> notification m
-    (NotProgressDone             m) -> notification m
+    (NotWorkDoneProgressBegin    m) -> notification m
+    (NotWorkDoneProgressReport   m) -> notification m
+    (NotWorkDoneProgressEnd      m) -> notification m
     (NotTelemetry                m) -> notification m
     (NotCancelRequestFromServer  m) -> notification m
     (NotCustomServer             m) -> notification m
@@ -148,6 +149,6 @@ handleClientMessage request response notification msg = case msg of
  (NotDidSaveTextDocument      m) -> notification m
  (NotDidChangeWatchedFiles    m) -> notification m
  (NotDidChangeWorkspaceFolders m) -> notification m
- (NotProgressCancel           m) -> notification m
+ (NotWorkDoneProgressCancel    m) -> notification m
  (ReqCustomClient             m) -> request m
  (NotCustomClient             m) -> notification m

--- a/stack.yaml
+++ b/stack.yaml
@@ -5,7 +5,7 @@ packages:
 extra-deps:
   - rope-utf16-splay-0.3.1.0
   - github: alanz/haskell-lsp
-    commit: fefcae8b44aaf7658e0f90d5530832efe0b32053
+    commit: 2aacc5ca706bcce111e976a1af4a95a376137c5e
     subdirs:
       - .
       - haskell-lsp-types

--- a/stack.yaml
+++ b/stack.yaml
@@ -4,5 +4,8 @@ packages:
 
 extra-deps:
   - rope-utf16-splay-0.3.1.0
-  - haskell-lsp-0.16.0.0
-  - haskell-lsp-types-0.16.0.0
+  - github: alanz/haskell-lsp
+    commit: fefcae8b44aaf7658e0f90d5530832efe0b32053
+    subdirs:
+      - .
+      - haskell-lsp-types

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -12,19 +12,37 @@ packages:
   original:
     hackage: rope-utf16-splay-0.3.1.0
 - completed:
-    hackage: haskell-lsp-0.16.0.0@sha256:6ac4b58e6caef43546a3c115f1aaaae0e23d30f0e37b8c4e94525468e9982d09,5264
+    size: 85195
+    subdir: .
+    url: https://github.com/alanz/haskell-lsp/archive/fefcae8b44aaf7658e0f90d5530832efe0b32053.tar.gz
+    cabal-file:
+      size: 5264
+      sha256: 6ac4b58e6caef43546a3c115f1aaaae0e23d30f0e37b8c4e94525468e9982d09
+    name: haskell-lsp
+    version: 0.16.0.0
+    sha256: 410af26154494735694ae323b3431d6a6ccb49ab6f028b56656039b5662de7d6
     pantry-tree:
-      size: 1725
-      sha256: 31b245f4da5b5b844be9802bb2bfd397c90c0a50b063e5bae26648c6220aaf7f
+      size: 5563
+      sha256: 4da14c5ad9e2e214d4c52edca1f8d24390f24f60375c00c99ade0e55a75821fa
   original:
-    hackage: haskell-lsp-0.16.0.0
+    subdir: .
+    url: https://github.com/alanz/haskell-lsp/archive/fefcae8b44aaf7658e0f90d5530832efe0b32053.tar.gz
 - completed:
-    hackage: haskell-lsp-types-0.16.0.0@sha256:57729b32b1ca65d4869e1e518fa4df749d4488ec5f11e23b50c2b89417f5f211,2882
+    size: 85195
+    subdir: haskell-lsp-types
+    url: https://github.com/alanz/haskell-lsp/archive/fefcae8b44aaf7658e0f90d5530832efe0b32053.tar.gz
+    cabal-file:
+      size: 2941
+      sha256: d5e3a1c45e2d8e6df35fa77122c396330546a5a7afe9b5d5c3393d937e18a66f
+    name: haskell-lsp-types
+    version: 0.16.0.0
+    sha256: 410af26154494735694ae323b3431d6a6ccb49ab6f028b56656039b5662de7d6
     pantry-tree:
-      size: 2369
-      sha256: cc24c23f741e777b9c01ccd700af034e2258e560f5fdb271d08befd4b03196b7
+      size: 2501
+      sha256: 409560d414a6618591d3bed1aaf046ba549a12c202a85e0ef9642004639399c5
   original:
-    hackage: haskell-lsp-types-0.16.0.0
+    subdir: haskell-lsp-types
+    url: https://github.com/alanz/haskell-lsp/archive/fefcae8b44aaf7658e0f90d5530832efe0b32053.tar.gz
 snapshots:
 - completed:
     size: 499889

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -12,37 +12,37 @@ packages:
   original:
     hackage: rope-utf16-splay-0.3.1.0
 - completed:
-    size: 85195
+    size: 86224
     subdir: .
-    url: https://github.com/alanz/haskell-lsp/archive/fefcae8b44aaf7658e0f90d5530832efe0b32053.tar.gz
+    url: https://github.com/alanz/haskell-lsp/archive/2aacc5ca706bcce111e976a1af4a95a376137c5e.tar.gz
     cabal-file:
       size: 5264
-      sha256: 6ac4b58e6caef43546a3c115f1aaaae0e23d30f0e37b8c4e94525468e9982d09
+      sha256: ddfcc2798f04bcb1ec20fafc02c03faa197322192578e879cef5852aba43ebcb
     name: haskell-lsp
-    version: 0.16.0.0
-    sha256: 410af26154494735694ae323b3431d6a6ccb49ab6f028b56656039b5662de7d6
+    version: 0.17.0.0
+    sha256: fbbc3ebdbb2c0f6eacdb9f3c8a3550e71617aff9df279da175c8b99c422ddeb9
     pantry-tree:
-      size: 5563
-      sha256: 4da14c5ad9e2e214d4c52edca1f8d24390f24f60375c00c99ade0e55a75821fa
+      size: 5675
+      sha256: 80539460483f0459786fce73d842b203eef003fd1c657281daec8aea2957db3f
   original:
     subdir: .
-    url: https://github.com/alanz/haskell-lsp/archive/fefcae8b44aaf7658e0f90d5530832efe0b32053.tar.gz
+    url: https://github.com/alanz/haskell-lsp/archive/2aacc5ca706bcce111e976a1af4a95a376137c5e.tar.gz
 - completed:
-    size: 85195
+    size: 86224
     subdir: haskell-lsp-types
-    url: https://github.com/alanz/haskell-lsp/archive/fefcae8b44aaf7658e0f90d5530832efe0b32053.tar.gz
+    url: https://github.com/alanz/haskell-lsp/archive/2aacc5ca706bcce111e976a1af4a95a376137c5e.tar.gz
     cabal-file:
       size: 2941
-      sha256: d5e3a1c45e2d8e6df35fa77122c396330546a5a7afe9b5d5c3393d937e18a66f
+      sha256: 9078237412d0596a7d09d432389c8fa21d6f3e21ed2ed761b3093a21607d6c28
     name: haskell-lsp-types
-    version: 0.16.0.0
-    sha256: 410af26154494735694ae323b3431d6a6ccb49ab6f028b56656039b5662de7d6
+    version: 0.17.0.0
+    sha256: fbbc3ebdbb2c0f6eacdb9f3c8a3550e71617aff9df279da175c8b99c422ddeb9
     pantry-tree:
       size: 2501
-      sha256: 409560d414a6618591d3bed1aaf046ba549a12c202a85e0ef9642004639399c5
+      sha256: a575ce26976bd31d34a9db27e20e8e34d9b50b8d2e34a2e3772b3236b8cf778c
   original:
     subdir: haskell-lsp-types
-    url: https://github.com/alanz/haskell-lsp/archive/fefcae8b44aaf7658e0f90d5530832efe0b32053.tar.gz
+    url: https://github.com/alanz/haskell-lsp/archive/2aacc5ca706bcce111e976a1af4a95a376137c5e.tar.gz
 snapshots:
 - completed:
     size: 499889

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -118,7 +118,7 @@ main = hspec $ do
               selector _ = False
               sesh = do
                 doc <- openDoc "Desktop/simple.hs" "haskell"
-                sendRequest TextDocumentDocumentSymbol (DocumentSymbolParams doc)
+                sendRequest TextDocumentDocumentSymbol (DocumentSymbolParams doc Nothing)
                 skipMany anyNotification
                 message :: Session RenameResponse -- the wrong type
             in runSession "hie" fullCaps "test/data/renamePass" sesh
@@ -154,7 +154,7 @@ main = hspec $ do
         let args = toJSON $ AOP (doc ^. uri)
                                 (Position 1 14)
                                 "Redundant bracket"
-            reqParams = ExecuteCommandParams "applyrefact:applyOne" (Just (List [args]))
+            reqParams = ExecuteCommandParams "applyrefact:applyOne" (Just (List [args])) Nothing
         request_ WorkspaceExecuteCommand reqParams
 
         editReq <- message :: Session ApplyWorkspaceEditRequest
@@ -177,7 +177,7 @@ main = hspec $ do
         let args = toJSON $ AOP (doc ^. uri)
                                 (Position 1 14)
                                 "Redundant bracket"
-            reqParams = ExecuteCommandParams "applyrefact:applyOne" (Just (List [args]))
+            reqParams = ExecuteCommandParams "applyrefact:applyOne" (Just (List [args])) Nothing
         request_ WorkspaceExecuteCommand reqParams
         contents <- getDocumentEdit doc
         liftIO $ contents `shouldBe` "main :: IO Int\nmain = return 42\n"


### PR DESCRIPTION
I’ve tested this with https://github.com/alanz/haskell-lsp/pull/188 on the `ghcide` test suite.

You probably want to wait until https://github.com/alanz/haskell-lsp/pull/189 is merged as well since without that you can end up interpreting the `WorkDoneProgressCreate` request as a response which breaks `responseForId` and thereby everything that relies on `request`.