### PR TITLE
Remove waitForProcess in finalizer

### DIFF
--- a/src/Language/Haskell/LSP/Test/Session.hs
+++ b/src/Language/Haskell/LSP/Test/Session.hs
@@ -71,7 +71,10 @@ import Language.Haskell.LSP.Test.Exceptions
 import System.Console.ANSI
 import System.Directory
 import System.IO
-import System.Process (waitForProcess, ProcessHandle())
+import System.Process (ProcessHandle())
+#ifndef mingw32_HOST_OS
+import System.Process (waitForProcess)
+#endif
 import System.Timeout
 
 -- | A session representing one instance of launching and connecting to a server.
@@ -271,7 +274,10 @@ runSessionWithHandles serverIn serverOut serverProc serverHandler config caps ro
           -- handles etc via cleanupProcess
           killThread tid
           -- Give the server some time to exit cleanly
+          -- It makes the server hangs in windows so we have to avoid it
+#ifndef mingw32_HOST_OS
           timeout msgTimeoutMs (waitForProcess serverProc)
+#endif
           cleanupProcess server
 
   (result, _) <- bracket serverListenerLauncher


### PR DESCRIPTION
It was causing hangs running test suites in Windows.
Not sure why it was included, i've tried to make it works but only removing it did it